### PR TITLE
Enable direct formatting of the 'ins' block

### DIFF
--- a/src/lib/ng2-adsense.ts
+++ b/src/lib/ng2-adsense.ts
@@ -8,29 +8,41 @@ import {
   OpaqueToken,
 } from '@angular/core';
 
+/* CommonModule required for ngStyle */
+import {CommonModule} from "@angular/common";
+
 export class AdsenseConfig {
+
   adClient?: string;
   adSlot?: string | number;
   adFormat?: string;
+  display?: string;
+  width?: number;
+  height?: number;
+
   constructor(config: AdsenseConfig = {}) {
     this.adClient = config.adClient || this.adClient;
     this.adSlot = config.adSlot || this.adSlot;
     this.adFormat = config.adFormat || this.adFormat;
+    this.display = config.display || 'block'
+    this.width = config.width
+    this.height = config.height
+
   }
 }
 
 @Component({
   selector: 'ng2-adsense',
   template: `
-  <div style="padding-bottom:8px;">
-    <ins class="adsbygoogle"
-      style="display:block;"
-      [attr.data-ad-client]="adClient"
-      [attr.data-ad-slot]="adSlot"
-      [attr.data-ad-format]="adFormat"
-      [attr.data-ad-region]="adRegion">
-    </ins>
-  </div>
+    <div style="padding-bottom:8px;">
+      <ins class="adsbygoogle"
+           [ngStyle]="{'display': display, 'width.px': width, 'height.px': height }"
+           [attr.data-ad-client]="adClient"
+           [attr.data-ad-slot]="adSlot"
+           [attr.data-ad-format]="adFormat"
+           [attr.data-ad-region]="adRegion">
+      </ins>
+    </div>
   `,
 })
 export class AdsenseComponent implements OnInit, AfterViewInit {
@@ -38,20 +50,20 @@ export class AdsenseComponent implements OnInit, AfterViewInit {
   @Input() adSlot: string | number;
   @Input() adFormat = 'auto';
   @Input() adRegion = 'page-' + Math.floor(Math.random() * 10000) + 1;
+  @Input() display:string;
+  @Input() width:number;
+  @Input() height:number;
   constructor(private config: AdsenseConfig) {
     // console.log(config);
     // console.log(this.adClient)
   }
   ngOnInit() {
-    if (!this.adClient && this.config.adClient) {
-      this.adClient = this.config.adClient;
-    }
-    if (!this.adSlot && this.config.adSlot) {
-      this.adSlot = this.config.adSlot;
-    }
-    if (!this.adFormat && this.config.adFormat) {
-      this.adFormat = this.config.adFormat;
-    }
+      this.adClient = this.adClient || this.config.adClient;
+      this.adSlot = this.adSlot || this.config.adSlot;
+      this.adFormat = this.adFormat || this.config.adFormat;
+      this.display = this.display || this.config.display;
+      this.width = this.width || this.config.width;
+      this.height = this.height || this.config.height;
   }
 
   ngAfterViewInit() {
@@ -80,6 +92,7 @@ export function provideAdsenseConfig(config: AdsenseConfig) {
 }
 
 @NgModule({
+  imports: [CommonModule],
   exports: [AdsenseComponent],
   declarations: [AdsenseComponent],
 })


### PR DESCRIPTION
When requesting a specific size of ad, Google provides an example code block in which the 'ins' block has width and height styles, and 'display: inline-block'. As per various Stackoverflow discussions, attempting to set these values using stylesheets often fails due to how AdSense scripts scrape for sizing info.

If you don't want these changes I certainly won't be offended if you just discard this request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scttcper/ng2-adsense/53)
<!-- Reviewable:end -->
