### PR TITLE
Fix package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install ng2-adsense
 
 Latest version available for each version of Angular
 
-| @ctrl/ngx-chartjs | Angular     |
+| ng2-adsense       | Angular     |
 | ----------------- | ----------- |
 | 5.4.3             | 5.x 6.x 7.x |
 | >6.0.0            | 8.x         |


### PR DESCRIPTION
This PR contains a small fix where the readme was displaying the wrong package name